### PR TITLE
Updated uglify-js to 2.4.24 due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "index.js"
   ],
   "dependencies": {
-    "uglify-js": "^2.4.23"
+    "uglify-js": "^2.4.24"
   },
   "devDependencies": {
     "test-jstransformer": "^1.0.0"


### PR DESCRIPTION
The article at https://zyan.scripts.mit.edu/blog/backdooring-js/ explains how one can leverage a bug in UglifyJS 2.4.23 and earlier to introduce security issues that manifest only in minified code.