### PR TITLE
Update uglify.js to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "index.js"
   ],
   "dependencies": {
-    "uglify-js": "^2.5.0"
+    "uglify-js": "^2.6.1"
   },
   "devDependencies": {
     "test-jstransformer": "^1.0.0"


### PR DESCRIPTION
To include a fix (mishoo/UglifyJS2@63d35f8) for https://nodesecurity.io/advisories/48

Please consider point-releasing a new version to include this fix!